### PR TITLE
ci: Update github-actions-report-lcov from v1 to v4

### DIFF
--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           ref: ${{ env.PR_SHA }}
       - name: Upload coverage artifact and post comment
-        uses: mbta/github-actions-report-lcov@v1
+        uses: mbta/github-actions-report-lcov@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           coverage-files: ${{ runner.temp }}/cover/lcov*.info


### PR DESCRIPTION
No ticket. Hopefully fixes [broken CI jobs](https://github.com/mbta/http_stage/actions/runs/13185754369/job/36807295169).