### PR TITLE
fix (test): Restore skipped test with a longer sleep

### DIFF
--- a/test/http_stage_test.exs
+++ b/test/http_stage_test.exs
@@ -259,16 +259,15 @@ defmodule HttpStageTest do
       assert take_events(producer, 1) == [["agent"]]
     end
 
-    # Skipping this test temporarily because it is failing occasionally in CI
-    # @tag :capture_log
-    # test "a fetch error is not fatal" do
-    #   {:ok, pid} = start_supervised({HttpStage, {"nodomain.dne", parser: & &1}})
+    @tag :capture_log
+    test "a fetch error is not fatal" do
+      {:ok, pid} = start_supervised({HttpStage, {"nodomain.dne", parser: & &1}})
 
-    #   # this will never finish, so run it in a separate process
-    #   Task.async(fn -> take_events(pid, 1) end)
-    #   :timer.sleep(50)
-    #   assert Process.alive?(pid)
-    # end
+      # this will never finish, so run it in a separate process
+      Task.async(fn -> take_events(pid, 1) end)
+      :timer.sleep(100)
+      assert Process.alive?(pid)
+    end
 
     defp start_producer(bypass, opts \\ []) do
       url = "http://127.0.0.1:#{bypass.port}/"


### PR DESCRIPTION
Restores the test skipped in https://github.com/mbta/http_stage/pull/27.