### PR TITLE
ci: Updates to fix zizmor warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: daily
       time: "09:00"
     cooldown:
-      default-days: 1
+      default-days: 7
     open-pull-requests-limit: 10
   - package-ecosystem: mix
     directory: "/"
@@ -14,6 +14,6 @@ updates:
       interval: daily
       time: "09:00"
     cooldown:
-      default-days: 1
+      default-days: 7
     open-pull-requests-limit: 10
     versioning-strategy: lockfile-only

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v4
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       # only install Hex/Rebar if we didn't hit the cache
       - if: steps.asdf-cache.outputs.cache-hit != 'true'
@@ -34,20 +34,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: asdf
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: ASDF cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
-      - uses: mbta/actions/reshim-asdf@v2
+      - uses: mbta/actions/reshim-asdf@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc # v2.21
       # The asdf job should have prepared the cache. exit if it didn't for some reason
       - run: exit 1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -69,8 +69,8 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > cover/PR_SHA
         if: github.event.pull_request
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: elixir-lcov
           path: cover/
-      - uses: mbta/actions/dialyzer@v2
+      - uses: mbta/actions/dialyzer@62db3e5c547c3c7f439c4a7fb98e69fc79c1a9cc # v2.21

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -35,6 +37,8 @@ jobs:
     needs: asdf
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: ASDF cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,6 +6,8 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   asdf:
     name: ASDF

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -70,9 +70,12 @@ jobs:
       - name: Run tests
         run: mix test --cover
       - name: Save PR information
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          echo "${{ github.event.pull_request.number }}" > cover/PR_NUMBER
-          echo "${{ github.event.pull_request.head.sha }}" > cover/PR_SHA
+          echo "$PR_NUMBER" > cover/PR_NUMBER
+          echo "$PR_SHA" > cover/PR_SHA
         if: github.event.pull_request
       - name: Upload coverage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  dependabot-cooldown:
+    config:
+      days: 1

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,4 +1,0 @@
-rules:
-  dependabot-cooldown:
-    config:
-      days: 1


### PR DESCRIPTION
Next step toward [Enable Zizmor on http_stage library](https://app.asana.com/1/15492006741476/project/1214062601513351/task/1216079783540110?focus=true)

config: Define the Zizmor minimum cooldown setting
This corresponds with the Dependabot setting defined in
https://github.com/mbta/http_stage/pull/76.

ci: Pin action references to specific SHAs
- actions/checkout v7.0.0
- actions/cache v6.1.0
- asdf-vm/actions/install v4.0.1
- actions/upload-artifact v7.0.1
- mbta/actions v2.21

ci: Disable credential persistence through GitHub Actions artifacts

ci: Restrict overly broad permissions

ci: Use env vars to prevent template injection